### PR TITLE
Make ingress port dynamic for ingress-restriction role integration

### DIFF
--- a/ansible/roles/openresty-v2/defaults/main.yml
+++ b/ansible/roles/openresty-v2/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
 # defaults file for openresty-v2
+
+# Port used by ingress-restriction role to restrict access.
+# Override this variable when using the ingress-restriction role.
+openresty_v2_ingress_port: 2222

--- a/ansible/roles/openresty-v2/tasks/main.yml
+++ b/ansible/roles/openresty-v2/tasks/main.yml
@@ -145,13 +145,13 @@
   args:
     chdir: /opt/web
 
-- name: Allow 2222
+- name: Allow ingress port
   iptables:
     action: insert
     chain: "INPUT"
     jump: ACCEPT
     protocol: tcp
-    destination_port: 2222
+    destination_port: "{{ openresty_v2_ingress_port }}"
 
 - name: Save iptables
   command: iptables-save -f /etc/iptables/rules.v4


### PR DESCRIPTION
## Changes

- Added `openresty_v2_ingress_port` variable (default: `2222`) to the defaults file
- Replaced hardcoded port `2222` in the iptables task with the dynamic variable
- Renamed the task from "Allow 2222" to "Allow ingress port" for clarity

## Why

This allows the `ingress-restriction` role to override the port when needed, making the openresty-v2 role more flexible and reusable across different configurations. The default of `2222` maintains backward compatibility with existing deployments.